### PR TITLE
Clarify NO_CACHE flag in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ Specify these eg. `docker compose -e FOO=bar up`:
 - `NO_CACHE`: When set to true, deletes temporary files after processing.
 
 > [!NOTE]
-> The flag `NO_CACHE` does not mean that files will not get downloaded to your local
-> storage, just that we'll delete the files once we're done with them
+> The flag NO_CACHE does not mean that files will not get downloaded to your local
+> storage (specifically, the ./data directory). It only means that we'll 
+> delete these temporary files from ./data once we're done processing them.
 
 These arguments are all configurable in the `docker-compose.yml` file.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Specify these eg. `docker compose -e FOO=bar up`:
 - `NO_CACHE`: When set to true, deletes temporary files after processing.
 
 > [!NOTE]
-> The flag NO_CACHE does not mean that files will not get downloaded to your local
+> The flag `NO_CACHE` does not mean that files will not get downloaded to your local
 > storage (specifically, the ./data directory). It only means that we'll 
 > delete these temporary files from ./data once we're done processing them.
 

--- a/db/README.md
+++ b/db/README.md
@@ -86,8 +86,8 @@ Predefined types (from load-values.sql):
 
 Categorizes different types of dependencies between packages.
 Predefined types (from load-values.sql):
-build
 
+- `build`
 - `development`
 - `runtime`
 - `test`


### PR DESCRIPTION
Brief: Added details about where temporary files are stored for the NO_CACHE flag.

Problem: The README's note on NO_CACHE explains that it doesn't prevent downloads but does delete temporary files after processing. This is helpful, but it doesn't explain where these files are stored even temporarily. This can lead to confusion about storage usage.

Solution: Specify the location of the temporary files (./data directory) to give users a concrete understanding of where disk space is being used, even temporarily.